### PR TITLE
Add old services back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tv.brannan.cloud",
-  "version": "1.8.0",
+  "version": "1.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tv.brannan.cloud",
-      "version": "1.8.0",
+      "version": "1.10.0",
       "dependencies": {
         "@azure/storage-blob": "~12.1.1",
         "axios": "~1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tv.brannan.cloud",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "dev": "vite dev",

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,6 +14,24 @@
     linkUrl="https://youtube.com/"
     imageUrl="https://files.brannan.cloud/tv-files/youtube-450x174.jpg"
   />
+
+  <StreamingService
+    name=""
+    linkUrl="https://www.hulu.com/"
+    imageUrl="https://files.brannan.cloud/tv-files/hulu-450x174.jpg"
+  />
+
+  <StreamingService
+    name=""
+    linkUrl="https://www.hulu.com/hub/sports"
+    imageUrl="https://files.brannan.cloud/tv-files/espn-450x174.jpg"
+  />
+
+  <StreamingService
+    name=""
+    linkUrl="https://www.disneyplus.com/"
+    imageUrl="https://files.brannan.cloud/tv-files/disney-450x174.png"
+  />
 </section>
 
 <style>

--- a/src/routes/whats-new/+page.svelte
+++ b/src/routes/whats-new/+page.svelte
@@ -1,5 +1,5 @@
 <article>
-  <h3>May 25th, 2024</h3>
+  <h3>May 26th, 2024</h3>
 
   <p>Summer is here, and with your new TV comes updates and housekeeping to your TV:</p>
   <ul>
@@ -8,13 +8,10 @@
       Updated what services you have and see on your homepage due to usage. If you would like to
       have them back, just let me know.
       <ul>
-        <li>Removed Hulu.</li>
         <li>Removed ABC Live News.</li>
-        <li>Removed ESPN+</li>
-        <li>Removed Paramount+</li>
       </ul>
     </li>
-    <li>Several minor style updates to make your TV look cleaner.</li>
+    <li>Made the header text a little bigger.</li>
     <li>Backend tweaks to keep your TV up to date.</li>
     <li>Added a button that allows mom to go "pro mode" if needed.</li>
   </ul>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added links to Hulu, ESPN, and Disney+ on the main page.
  - Introduced "pro mode" for a TV interface.

- **Updates**
  - Updated the version to 1.10.0.
  - Modified the date display and style on the "What's New" page.
  - Removed certain services from the "What's New" list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->